### PR TITLE
fix directory import is not supported resolving ES modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "nodemon": "^2.0.18"
   },
   "scripts": {
-    "start": "babel-node ./src/service/index.js",
-    "start:2": "HTTP_PORT=3001 NETWORK_PORT=5001 NODES=ws:localhost:5000 babel-node ./src/service/index.js",
+    "start": "NODE_OPTIONS='--experimental-vm-modules --experimental-specifier-resolution=node' babel-node ./src/service/index.js",
+    "start:2": "HTTP_PORT=3001 NETWORK_PORT=5001 NODES=ws:localhost:5000 NODE_OPTIONS='--experimental-vm-modules --experimental-specifier-resolution=node' babel-node ./src/service/index.js",
     "nodemon": "nodemon --exec npm start",
     "lint": "eslint index.js src",
     "test": "NODE_OPTIONS='--experimental-vm-modules --experimental-specifier-resolution=node' jest",


### PR DESCRIPTION
Este PR es para arreglar un problema donde ES no soporta importar por medio de referencias de directorios (o yo no pude hacerlo).
Revisando documentación lo habia solucionado en los test pero me había olvidado de arreglarlo en la ejecución de la app mediante npm.

`NODE_OPTIONS='--experimental-vm-modules --experimental-specifier-resolution=node'`