### PR TITLE
[WIP] Miner transaction and remove transaction from memoryPool

### DIFF
--- a/src/blockchain/memoryPool.js
+++ b/src/blockchain/memoryPool.js
@@ -20,6 +20,10 @@ class MemoryPool {
     find(address) {
         return this.transactions.find(({ input }) => input.address === address);
     }
+
+    wipe() {
+        this.transactions = [];
+    }
 }
 
 export default MemoryPool;

--- a/src/blockchain/memoryPool.test.js
+++ b/src/blockchain/memoryPool.test.js
@@ -47,4 +47,9 @@ describe('MemoryPool', () => {
     expect(memoryPool.transactions.length).toEqual(1);
     expect(found).not.toEqual(undefined);
   });
+
+  it('wipes transactions', () => {
+    memoryPool.wipe();
+    expect(memoryPool.transactions.length).toEqual(0);
+  });  
 });

--- a/src/miner/miner.js
+++ b/src/miner/miner.js
@@ -1,4 +1,5 @@
 import { Transaction, blockchainWallet } from '../wallet';
+import { MESSAGES } from '../service/network';
 
 class Miner {
     constructor(blockchain, networkService, wallet) {
@@ -20,7 +21,8 @@ class Miner {
       const block = this.blockchain.addBlock(memoryPool.transactions);
       networkService.sync();
       memoryPool.wipe();
-      
+      networkService.broadcast(MESSAGES.TXWIPE);
+
       return block;
     }
   }

--- a/src/miner/miner.js
+++ b/src/miner/miner.js
@@ -1,0 +1,27 @@
+import { Transaction, blockchainWallet } from '../wallet';
+
+class Miner {
+    constructor(blockchain, networkService, wallet) {
+      this.blockchain = blockchain;
+      this.networkService = networkService;
+      this.wallet = wallet;
+    }
+  
+    mine() {
+      const {
+        blockchain: { memoryPool },
+        networkService,
+        wallet,
+      } = this;
+
+      if (memoryPool.transactions.length === 0) throw Error('There are no unconfirmed transactions.');
+
+      memoryPool.transactions.push(Transaction.reward(wallet, blockchainWallet));
+      const block = this.blockchain.addBlock(memoryPool.transactions);
+      networkService.sync();
+  
+      return block;
+    }
+  }
+  
+  export default Miner;

--- a/src/miner/miner.js
+++ b/src/miner/miner.js
@@ -19,7 +19,8 @@ class Miner {
       memoryPool.transactions.push(Transaction.reward(wallet, blockchainWallet));
       const block = this.blockchain.addBlock(memoryPool.transactions);
       networkService.sync();
-  
+      memoryPool.wipe();
+      
       return block;
     }
   }

--- a/src/service/network.js
+++ b/src/service/network.js
@@ -2,7 +2,7 @@ import WebSocket, { WebSocketServer } from 'ws';
 
 const { NETWORK_PORT = 5000, NODES } = process.env;
 const nodes = NODES ? NODES.split(',') : [];
-const MESSAGES = { BLOCKS: 'blocks', 'TX': 'Transactions' };
+const MESSAGES = { BLOCKS: 'blocks', TX: 'Transactions', TXWIPE: 'wipeMemoryPool' };
 
 class NetworkService {
     constructor(blockchain) {
@@ -34,6 +34,7 @@ class NetworkService {
             try {
                 if (type === MESSAGES.BLOCKS) blockchain.replace(value);
                 else if (type === MESSAGES.TX) blockchain.memoryPool.addOrUpdate(value);
+                else if (type === MESSAGES.TXWIPE) blockchain.memoryPool.wipe();
             } catch (error) {
                 console.log(`[ws:message] error ${error}`);
                 throw Error(error);

--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -1,5 +1,7 @@
 import Transaction from './transaction';
 import Wallet from './wallet';
 
-export { Transaction };
+const blockchainWallet = new Wallet();
+
+export { Transaction, blockchainWallet };
 export default Wallet;

--- a/src/wallet/transaction.js
+++ b/src/wallet/transaction.js
@@ -1,6 +1,8 @@
 import { v1 as uuidV1 } from 'uuid';
 import { elliptic } from '../modules';
 
+const REWARD = 1;
+
 class Transaction {
     constructor() {
         this.id = uuidV1();
@@ -49,7 +51,12 @@ class Transaction {
         this.input = Transaction.sign(this, senderWallet);
     
         return this;
-    }    
+    }
+
+    static reward(minerWallet, blockchainWallet) {
+        return this.create(blockchainWallet, minerWallet.publicKey, REWARD);
+    }
 };
 
+export { REWARD };
 export default Transaction;

--- a/src/wallet/transaction.test.js
+++ b/src/wallet/transaction.test.js
@@ -1,5 +1,6 @@
-import Transaction from './transaction';
+import Transaction, { REWARD } from './transaction';
 import Wallet from './wallet';
+import { blockchainWallet } from './index';
 
 describe('Transaction', () => {
     let wallet;
@@ -61,19 +62,36 @@ describe('Transaction', () => {
         let nextAddress;
     
         beforeEach(() => {
-          nextAmount = 3;
-          nextAddress = 'n3xt-4ddr3ss';
-          transaction = transaction.update(wallet, nextAddress, nextAmount);
+            nextAmount = 3;
+            nextAddress = 'n3xt-4ddr3ss';
+            transaction = transaction.update(wallet, nextAddress, nextAmount);
         });
     
         it('subtracts the next amount from the senders wallet', () => {
-          const output = transaction.outputs.find(({ address }) => address === wallet.publicKey);
-          expect(output.amount).toEqual(wallet.balance - amount - nextAmount);
+            const output = transaction.outputs.find(({ address }) => address === wallet.publicKey);
+            expect(output.amount).toEqual(wallet.balance - amount - nextAmount);
         });
     
         it('outputs an amount for the next receiver', () => {
-          const output = transaction.outputs.find(({ address }) => address === nextAddress);
-          expect(output.amount).toEqual(nextAmount);
+            const output = transaction.outputs.find(({ address }) => address === nextAddress);
+            expect(output.amount).toEqual(nextAmount);
         });
-      });    
+    });
+    
+    describe('creating a reward transaction', () => {
+        beforeEach(() => {
+            blockchainWallet.balance = 100;
+            transaction = Transaction.reward(wallet, blockchainWallet);
+        });
+    
+        it('reward the miners wallet', () => {
+            expect(transaction.outputs.length).toEqual(2);
+
+            let output = transaction.outputs.find(({ address }) => address === wallet.publicKey);
+            expect(output.amount).toEqual(REWARD);
+
+            output = transaction.outputs.find(({ address }) => address === blockchainWallet.publicKey);
+            expect(output.amount).toEqual(blockchainWallet.balance - REWARD);
+        });
+    });
 });

--- a/src/wallet/wallet.js
+++ b/src/wallet/wallet.js
@@ -4,8 +4,8 @@ import Transaction from './transaction';
 const INITIAL_BALANCE = 0;
 
 class Wallet {
-    constructor(blockchain) {
-        this.balance = INITIAL_BALANCE;
+    constructor(blockchain, initialBalance = INITIAL_BALANCE) {
+        this.balance = initialBalance;
         this.keyPair = elliptic.createKeyPair();
         this.publicKey = this.keyPair.getPublic().encode('hex');
         this.blockchain = blockchain;


### PR DESCRIPTION
El objetivo de este PR es implementar la funcionalidad del minero en nuestra blockchain.
Esta nueva funcionalidad se encargaría de tomar todas las transacciones que tenemos en la memoryPool y guardarlas en un bloque en la blockchain.
También vamos a implementar una propiedad de la minería llamada rewards que es lo que se le paga al minero por realizar el trabajo de buscar la solución al algoritmo de PoW que ya implementamos anteriormente para poder confirmar un bloque nuevo con los datos de las transacciones, inmediatamente también tenemos que vaciar nuestra memoryPool y avisar por medio de la comunicación broadcast entre nodos que hemos minado y persistido las transacciones.
